### PR TITLE
Padronização dos controllers 

### DIFF
--- a/infra/database.js
+++ b/infra/database.js
@@ -1,4 +1,5 @@
 import { Client } from "pg";
+import { ServiceError } from "infra/errors";
 
 async function query(queryObj) {
   let client;
@@ -8,8 +9,11 @@ async function query(queryObj) {
     const result = await client.query(queryObj);
     return result;
   } catch (error) {
-    console.error(error);
-    throw error;
+    const serviceError = new ServiceError({
+      cause: error,
+      message: "Erro na conexão com o banco de dados ou na query.",
+    });
+    throw serviceError;
   } finally {
     if (client instanceof Client) {
       await client.end();

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -1,11 +1,9 @@
-export class InternalServerError extends Error {
-  constructor({ cause }) {
-    super("Erro interno do servidor.", {
-      cause,
-    });
-    this.name = "InternalServerError";
-    this.action = "Entre em contato com o suporte.";
-    this.statusCode = 500;
+class ApiError extends Error {
+  constructor({ name, message, action, statusCode, cause }) {
+    super(message, { cause });
+    this.name = name;
+    this.action = action;
+    this.statusCode = statusCode;
   }
 
   toJSON() {
@@ -15,5 +13,40 @@ export class InternalServerError extends Error {
       action: this.action,
       status_code: this.statusCode,
     };
+  }
+}
+
+export class InternalServerError extends ApiError {
+  constructor({ statusCode, cause }) {
+    super({
+      name: "InternalServerError",
+      message: "Erro interno do servidor.",
+      action: "Entre em contato com o suporte.",
+      statusCode: statusCode ?? 500,
+      cause,
+    });
+  }
+}
+
+export class MethodNotAllowedError extends ApiError {
+  constructor() {
+    super({
+      name: "MethodNotAllowedError",
+      message: "Método não permitido para este endpoint.",
+      action: "Verifique se o método HTTP está correto.",
+      statusCode: 405,
+    });
+  }
+}
+
+export class ServiceError extends ApiError {
+  constructor({ cause, message }) {
+    super({
+      name: "ServiceError",
+      message: message ?? "Serviço indisponível no momento.",
+      action: "Verifique se o serviço está disponível.",
+      statusCode: 503,
+      cause,
+    });
   }
 }

--- a/infra/middlewares.js
+++ b/infra/middlewares.js
@@ -1,0 +1,21 @@
+import { InternalServerError, MethodNotAllowedError } from "infra/errors";
+
+function onNoMatchHandler(_, response) {
+  const methodNotAllowedError = new MethodNotAllowedError();
+  console.error(methodNotAllowedError);
+  response.status(405).json(methodNotAllowedError);
+}
+
+function onErrorHandler(error, _, response) {
+  const internalServerError = new InternalServerError({
+    statusCode: error.statusCode,
+    cause: error,
+  });
+  console.error(internalServerError);
+  response.status(internalServerError.statusCode).json(internalServerError);
+}
+
+export const errorMiddleware = {
+  onError: onErrorHandler,
+  onNoMatch: onNoMatchHandler,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "16.4.5",
         "dotenv-expand": "11.0.6",
         "next": "14.2.5",
+        "next-connect": "1.0.0",
         "node-pg-migrate": "7.6.1",
         "pg": "8.12.0",
         "react": "18.3.1",
@@ -2072,6 +2073,12 @@
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -8748,6 +8755,19 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9767,6 +9787,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "dotenv": "16.4.5",
     "dotenv-expand": "11.0.6",
     "next": "14.2.5",
+    "next-connect": "1.0.0",
     "node-pg-migrate": "7.6.1",
     "pg": "8.12.0",
     "react": "18.3.1",

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,8 +1,17 @@
 import migrationRunner from "node-pg-migrate";
 import { resolve } from "node:path";
-import { getNewClient } from "infra/database";
+import { createRouter } from "next-connect";
 
-export default async function getMigration(request, response) {
+import { getNewClient } from "infra/database";
+import { errorMiddleware } from "infra/middlewares";
+
+const router = createRouter();
+
+router.get(getHandler).post(getHandler);
+
+export default router.handler(errorMiddleware);
+
+async function getHandler(request, response) {
   const allowedMethods = ["GET", "POST"];
 
   if (!allowedMethods.includes(request.method)) {

--- a/tests/integration/api/v1/status/post.test.js
+++ b/tests/integration/api/v1/status/post.test.js
@@ -1,0 +1,23 @@
+import { waitForAllServices, apiUrl } from "tests/orchestrator";
+
+beforeAll(async () => {
+  await waitForAllServices();
+});
+
+describe("POST /status", () => {
+  describe("Anonymous user", () => {
+    it("Getting current system status", async () => {
+      const response = await fetch(apiUrl + "/status", { method: "POST" });
+      const responseBody = await response.json();
+
+      expect(response.status).toBe(405);
+
+      expect(responseBody).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Método não permitido para este endpoint.",
+        action: "Verifique se o método HTTP está correto.",
+        status_code: 405,
+      });
+    });
+  });
+});


### PR DESCRIPTION
1 Adiciona o `next-connect` a aplicação.
2 Refatora os controllers dos endpoints `/api/v1/status` e `/api/v1/migrations`.
3 Adição de novos erros personalizados. 
